### PR TITLE
(docs) Add automatic generation of TOC content

### DIFF
--- a/.github/workflows/toc.yml
+++ b/.github/workflows/toc.yml
@@ -1,0 +1,21 @@
+name: TOC Generator
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  generateTOC:
+    name: TOC Generator
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: technote-space/toc-generator@v4.0.0
+
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CREATE_PR: true
+          TARGET_PATHS: "README*.md,CONTRIBUTING*.md"
+          FOLDING: true
+          COMMIT_MESSAGE: '(docs) Update TOC'
+          PR_TITLE: '(docs) Update TOC (${PR_MERGE_REF})'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,12 @@ For existing packages that no longer fit above principles chocolatey-community u
 
 The following sections present complete set of guideliness, please read them carefully, especially since some of the rules are enforced and if broken will result in the failed PR build.
 
+<!-- markdownlint-disable -->
+<!-- START doctoc -->
+<!-- END doctoc -->
+
+<!-- markdownlint-enable -->
+
 # 1. Packages
 
 ## 1.1 Basics

--- a/README.md
+++ b/README.md
@@ -8,6 +8,13 @@
 [![](http://transparent-favicon.info/favicon.ico)](#)
 [community.chocolatey.org profile](https://community.chocolatey.org/profiles/chocolatey-community)
 
+<!-- markdownlint-disable -->
+<!-- START doctoc -->
+<!-- param::title: '**Table of Contents**' -->
+<!-- END doctoc -->
+
+<!-- markdownlint-enable -->
+
 ### Description
 
 This repository contains Chocolatey packages, most of which are [automatically](https://docs.chocolatey.org/en-us/create/automatic-packages) updated.


### PR DESCRIPTION
## Description

This pull request adds a new GitHub Action workflow that will generate and push a new commit to the repository when it needs to update the TOC content for both the Readme.md and Contributing.md files.

## Motivation and Context

To have a TOC available for the files, without the need for us to create the TOC content manually.

## How Has this Been Tested?

1. Tested on my fork to ensure that it works as expected. See https://github.com/AdmiringWorm/chocolatey-coreteampackages/commit/312146ba6f67b7282bf1ebf435fd9e1453611013 as what it will create for this PR.

## Screenshot (if appropriate, usually isn't needed):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)
- [x] Documentation

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this repository.
- [x] My change requires a change to documentation (this usually means the notes in the description of a package). (Will happen automatically)
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] I have updated the package description and it is less than 4000 characters.
- [x] All files are up to date with the latest [Contributing Guidelines](https://github.com/chocolatey-community/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [ ] The changes only affect a single package (not including meta package).

<!-- The following section can be removed if the package has not been migrated from another location -->
## Original Location

N/A

## Related Issues

Loosely related to #1754